### PR TITLE
⚡ Bolt: optimize ChatSearch with debounce

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,8 @@
 
 **Learning:** In a chat application where messages are streamed token by token, the entire message list often re-renders. When messages contain large base64 images, this causes significant UI jank. 'React.memo' on the message component is the most effective way to prevent these redundant re-renders. Additionally, 'decoding="async"' on image tags is crucial for offloading the heavy work of base64 image decoding from the main thread.
 **Action:** Always memoize core list components in real-time interfaces and use asynchronous image decoding for heavy assets.
+
+## 2025-05-20 - [Search Filtering Debouncing]
+
+**Learning:** In interfaces with large lists (like chat histories), executing complex fuzzy search filtering on every keystroke can lead to noticeable UI lag, especially on lower-end devices or with long conversations. Debouncing the search logic by even a small amount (200ms) significantly improves the perceived responsiveness of the input field by ensuring the CPU isn't overwhelmed by redundant filtering operations during rapid typing.
+**Action:** Always debounce search filtering logic in client-side list filtering components.

--- a/web/src/pages/gptchat/components/__tests__/chat-search.test.tsx
+++ b/web/src/pages/gptchat/components/__tests__/chat-search.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ChatSearch } from '../chat-search'
+import type { ChatMessageData } from '../../types'
+import '@testing-library/jest-dom'
+
+// Mock TooltipWrapper to avoid Radix UI issues in tests
+vi.mock('@/components/ui/tooltip-wrapper', () => ({
+  TooltipWrapper: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+describe('ChatSearch', () => {
+  const mockMessages: ChatMessageData[] = [
+    { chatID: '1', role: 'user', content: 'apple pie', timestamp: Date.now() },
+    { chatID: '2', role: 'assistant', content: 'banana bread', timestamp: Date.now() },
+    { chatID: '3', role: 'user', content: 'cherry tart', timestamp: Date.now() },
+  ]
+
+  it('debounces the search query', async () => {
+    vi.useFakeTimers()
+    const onSelectMessage = vi.fn()
+
+    render(<ChatSearch messages={mockMessages} onSelectMessage={onSelectMessage} />)
+
+    // Open the search dialog
+    const searchButton = screen.getByLabelText('Search messages')
+    fireEvent.click(searchButton)
+
+    const input = screen.getByPlaceholderText('Search messages...')
+
+    // Type 'apple' rapidly
+    fireEvent.change(input, { target: { value: 'apple' } })
+
+    // Effect with debounce hasn't run yet
+    expect(screen.queryByText('apple pie')).not.toBeInTheDocument()
+
+    // Fast forward 100ms - still shouldn't have results (debounce is 200ms)
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(screen.queryByText('apple pie')).not.toBeInTheDocument()
+
+    // Fast forward another 150ms (total 250ms)
+    act(() => {
+      vi.advanceTimersByTime(150)
+    })
+
+    expect(screen.getByText('apple pie')).toBeInTheDocument()
+    expect(screen.queryByText('banana bread')).not.toBeInTheDocument()
+
+    vi.useRealTimers()
+  })
+})

--- a/web/src/pages/gptchat/components/chat-search.tsx
+++ b/web/src/pages/gptchat/components/chat-search.tsx
@@ -54,24 +54,28 @@ export function ChatSearch({
     }
   }, [isOpen])
 
-  // Simple fuzzy search (matches all words)
+  // Simple fuzzy search (matches all words) with debouncing to prevent excessive filtering during rapid typing.
   useEffect(() => {
     if (!query.trim()) {
       setResults([])
       return
     }
 
-    const words = query.toLowerCase().trim().split(/\s+/)
-    const filtered = messages
-      .filter((m) => {
-        const content = m.content.toLowerCase()
-        return words.every((word) => content.includes(word))
-      })
-      .reverse() // Newest results first
-      .slice(0, 50) // Limit results
+    const timer = setTimeout(() => {
+      const words = query.toLowerCase().trim().split(/\s+/)
+      const filtered = messages
+        .filter((m) => {
+          const content = m.content.toLowerCase()
+          return words.every((word) => content.includes(word))
+        })
+        .reverse() // Newest results first
+        .slice(0, 50) // Limit results
 
-    setResults(filtered)
-    setSelectedIndex(0)
+      setResults(filtered)
+      setSelectedIndex(0)
+    }, 200)
+
+    return () => clearTimeout(timer)
   }, [query, messages])
 
   const handleSelect = useCallback(


### PR DESCRIPTION
The `ChatSearch` component now has a 200ms debounce on its search input. This optimization ensures that the fuzzy filtering logic (which can be expensive with many messages) only runs after the user has paused typing, rather than on every single keystroke. This makes the search input feel much more responsive in sessions with many messages.

Changes:
- Added `setTimeout` and `clearTimeout` to the search `useEffect` in `web/src/pages/gptchat/components/chat-search.tsx`.
- Added a new unit test `web/src/pages/gptchat/components/__tests__/chat-search.test.tsx` to verify the debounce logic using Vitest fake timers.
- Updated `.jules/bolt.md` with critical learnings from this performance boost.

---
*PR created automatically by Jules for task [17595309077774732443](https://jules.google.com/task/17595309077774732443) started by @Laisky*